### PR TITLE
CoolDown, GameOver, Sunpoints, Illegal Plant Placement Logic Implemented in GUI

### DIFF
--- a/PlantsVZombies/src/ca/carleton/pvz/ActionProcessor.java
+++ b/PlantsVZombies/src/ca/carleton/pvz/ActionProcessor.java
@@ -13,11 +13,11 @@ public class ActionProcessor {
 	private int previousTurn;
 	private int peaShooterCooldown;
 	private int sunflowerCooldown;
-	private boolean peaShooterOnCooldown;
-	private boolean sunflowerOnCooldown;
+	public boolean peaShooterOnCooldown;
+	public boolean sunflowerOnCooldown;
 	private boolean waveDefeated;
 	private int sunPoints; // in-game currency spent on plants
-	private int turn;
+	public int turn;
 
 	private Wave wave;
 	private PlantsVZombies game;
@@ -33,6 +33,47 @@ public class ActionProcessor {
 		peaShooterOnCooldown = false;
 		sunflowerOnCooldown = false;
 		waveDefeated = false;
+	}
+
+	public int getSunpoints() {
+		return sunPoints;
+	}
+
+	public void setSunpoints(int i) {
+		sunPoints += i;
+	}
+
+	public boolean processPeaShooterCooldown() {
+
+		if (peaShooterOnCooldown && turn - peaShooterCooldown == 2) {
+			peaShooterOnCooldown = false;
+		}
+
+		return peaShooterOnCooldown;
+
+	}
+
+	public boolean processSunflowerCooldown() {
+
+		if (sunflowerOnCooldown && turn - sunflowerCooldown == 2) {
+			sunflowerOnCooldown = false;
+		}
+
+		return sunflowerOnCooldown;
+
+	}
+
+	public boolean isGameOver() {
+		if (turn > 6) { // searching for any zombies that made it to end game
+			for (int j = 0; j < game.getWorld().getCurrentLevel().getDimension().width; ++j) {
+				Actor o = game.getWorld().getCurrentLevel().getCell(0, j);
+				if (o instanceof Zombie) {
+					return true;
+				}
+			}
+
+		}
+		return false;
 	}
 
 	public void processNextTurn() {
@@ -55,13 +96,9 @@ public class ActionProcessor {
 			return;
 		}
 
-		if (sunflowerOnCooldown && turn - sunflowerCooldown == 2) {
-			sunflowerOnCooldown = false;
-		}
+		processSunflowerCooldown();
 
-		if (peaShooterOnCooldown && turn - peaShooterCooldown == 2) {
-			peaShooterOnCooldown = false;
-		}
+		processPeaShooterCooldown();
 
 		// passive sun point logic -- every three turns, increase sun points by 25
 		if (turn - previousTurn == 3) {
@@ -89,7 +126,7 @@ public class ActionProcessor {
 		}
 
 		if (wave.getNum() == 1 && turn >= 3 && wave.getRemainingZombies() > 0) { // zombies spawn after turn
-																						// == 3 for first wave
+																					// == 3 for first wave
 			game.print(Presets.ZOMBIES_SPAWNING);
 			game.getWorld().updateCurrentLevel(Wave.spawnZombieOnLevel(game.getWorld().getCurrentLevel()));
 			wave.setRemainingZombies(wave.getRemainingZombies() - 1);
@@ -107,16 +144,13 @@ public class ActionProcessor {
 			wave.setRemainingZombies(wave.getRemainingZombies() - 1);
 		}
 
-		if (turn > 6) { // searching for any zombies that made it to end game
-			for (int j = 0; j < game.getWorld().getCurrentLevel().getDimension().width; ++j) {
-				Actor o = game.getWorld().getCurrentLevel().getCell(0, j);
-				if (o instanceof Zombie) {
-					game.printGame();
-					game.print(Presets.GAME_OVER);
-					game.setGameOver();
-					return;
-				}
-			}
+		isGameOver();
+
+		if (isGameOver()) {
+			game.printGame();
+			game.print(Presets.GAME_OVER);
+			game.setGameOver();
+			return;
 		}
 
 		if ((wave.getNum() == 1 && turn >= 6) || (wave.getNum() == 2 && turn >= 8)
@@ -184,6 +218,7 @@ public class ActionProcessor {
 				peaShooterCooldown = turn;
 				game.print("\nYou currently have " + sunPoints + " sun points.\n");
 				game.printGame();
+
 			}
 		} else if (actor instanceof Sunflower) {
 			plantType = "sunflower";

--- a/PlantsVZombies/src/ca/carleton/pvz/gui/GUIController.java
+++ b/PlantsVZombies/src/ca/carleton/pvz/gui/GUIController.java
@@ -16,12 +16,16 @@ import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.scene.Group;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.GridPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
 
 /**
  * This class controls the JavaFX fxml user interface.
@@ -33,12 +37,18 @@ public class GUIController {
 	private PlantsVZombies game;
 	private Plant selectedPlant;
 
+	private int sunflowerCooldownInt = 0;
+	private int peashooterCooldownInt = 0;
+
 	@FXML
 	private ResourceBundle resources;
 
 	@FXML
 	private URL location;
 
+	// @FXML
+	// private Label sunpoints;
+	
 	@FXML
 	private Label peashooterCooldown;
 
@@ -74,11 +84,47 @@ public class GUIController {
 		nextTurnButton.setOnAction(new EventHandler<ActionEvent>() {
 			@Override
 			public void handle(ActionEvent e) {
-				// testing controller -> game interaction
-				game.getActionProcessor().processPlaceActor(new Sunflower(), 0, 0);
-				game.getActionProcessor().processPlaceActor(new PeaShooter(), 0, 3);
-				updateGameGrid();
+				if (game.getActionProcessor().isGameOver()) {
+
+					updateGameGrid();
+					nextTurnButton.setDisable(true);
+					peashooterButton.setDisable(true);
+					sunflowerButton.setDisable(true);
+					gameGrid.setDisable(true);
+					plantGroup.setDisable(true);
+					Label label = new Label("Game over! You failed to protect your home from the zombies :(");
+
+					StackPane secondaryLayout = new StackPane();
+					secondaryLayout.getChildren().add(label);
+
+					Scene secondScene = new Scene(secondaryLayout, 400, 100);
+
+					// New window (Stage)
+					Stage newWindow = new Stage();
+					newWindow.setTitle("Game Over");
+					newWindow.setScene(secondScene);
+
+					// Specifies the modality for new window.
+					newWindow.initModality(Modality.WINDOW_MODAL);
+
+					newWindow.show();
+
+				}
+
+				if (sunflowerCooldownInt > 0) {
+					sunflowerCooldownInt = sunflowerCooldownInt - 1;
+					sunflowerCooldown.setText(Integer.toString(sunflowerCooldownInt));
+				}
+				if (peashooterCooldownInt > 0) {
+					peashooterCooldownInt = peashooterCooldownInt - 1;
+					peashooterCooldown.setText(Integer.toString(sunflowerCooldownInt));
+				}
+				
+				//Updating Sunpoints
+				//sunpoints.setText(Integer.toString(game.getActionProcessor().getSunpoints()));
 				game.getActionProcessor().processNextTurn();
+				updateGameGrid();
+
 			}
 		});
 
@@ -93,8 +139,8 @@ public class GUIController {
 	}
 
 	/**
-	 * Sets up plant button event handlers. When button is pressed, sets
-	 * currently selected plant object to correct type.
+	 * Sets up plant button event handlers. When button is pressed, sets currently
+	 * selected plant object to correct type.
 	 */
 	private void setupPlantSelectionButtons() {
 		selectedPlant = new Sunflower();
@@ -138,18 +184,64 @@ public class GUIController {
 							row = GridPane.getRowIndex(imgView);
 							column = GridPane.getColumnIndex(imgView);
 							if (game.getWorld().getCurrentLevel().getCell(column, row) == null) {
-								// TODO Check cooldown before placing!
-								game.getWorld().getCurrentLevel().placeActor(selectedPlant, new Point(column, row));
+								if (selectedPlant instanceof PeaShooter) {
+									if (peashooterCooldownInt == 0
+											&& (game.getActionProcessor().getSunpoints() >= 100)) {
+										System.out.println(peashooterCooldownInt);
+										game.getWorld().getCurrentLevel().placeActor(selectedPlant,
+												new Point(column, row));
+										peashooterCooldownInt = 2;
+										game.getActionProcessor().setSunpoints(-100);
+										peashooterCooldown.setText(Integer.toString(peashooterCooldownInt));
+										//Updating Sunpoints
+										//sunpoints.setText(Integer.toString(game.getActionProcessor().getSunpoints()));
+
+									}
+								}
+
+								if (selectedPlant instanceof Sunflower
+										&& (game.getActionProcessor().getSunpoints() >= 50)) {
+									if (sunflowerCooldownInt == 0) {
+										game.getWorld().getCurrentLevel().placeActor(selectedPlant,
+												new Point(column, row));
+										sunflowerCooldownInt = 2;
+										game.getActionProcessor().setSunpoints(-50);
+										sunflowerCooldown.setText(Integer.toString(sunflowerCooldownInt));
+										//Updating Sunpoints
+										//sunpoints.setText(Integer.toString(game.getActionProcessor().getSunpoints()));
+									}
+								}
+
 							} else {
-								System.out.println("there's already something placed here!");
+
+								Label label = new Label("There's already something placed here!");
+
+								StackPane secondaryLayout = new StackPane();
+								secondaryLayout.getChildren().add(label);
+
+								Scene secondScene = new Scene(secondaryLayout, 230, 100);
+
+								// New window (Stage)
+								Stage newWindow = new Stage();
+								newWindow.setTitle("Error");
+								newWindow.setScene(secondScene);
+
+								// Specifies the modality for new window.
+								newWindow.initModality(Modality.WINDOW_MODAL);
+
+								newWindow.show();
+
 							}
 						}
 						updateGameGrid();
 						event.consume();
+
 					}
+
 				});
 			}
 		}
+
 	}
 
 	/**
@@ -196,7 +288,8 @@ public class GUIController {
 	/**
 	 * Set the game that this controller controls
 	 *
-	 * @param game to control
+	 * @param game
+	 *            to control
 	 */
 	public void setGame(PlantsVZombies game) {
 		this.game = game;


### PR DESCRIPTION
coolDown Logic implemented with actively updating labels that update each turn during cooldown and when a plant is placed
Attempting to place a plant on a previously placed plant will result in a message box telling user that the move is illegal
Placing a plant now checks if user has enough sunpoints to purchase a plant

gameOver Logic implemented with buttons being disabled and message box telling user that game is over, however currently this is occuring one turn too late as of right now

